### PR TITLE
README/manpage: point to the curl issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Ben Zanin
 # Reporting Bugs
 
 If you experience any problems with **wcurl** that you do not experience with curl,
-submit an issue on the Debian Bug Tracking System.
+submit an issue [here](https://github.com/curl/wcurl/issues).
 
 <a name="copyright"></a>
 

--- a/wcurl.1
+++ b/wcurl.1
@@ -86,13 +86,9 @@ Ryan Carsten Schmidt <git@ryandesign.com>
 Ben Zanin
 .SH REPORTING BUGS
 If you experience any problems with \fBwcurl\fR that you do not experience with curl,
-submit an issue on the Debian Bug Tracking System.
-.PP
-Alternatively, you can also submit an issue on Github or Debian's salsa:
+submit an issue on Github:
 .br
-https://github.com/Debian/wcurl
-.br
-https://salsa.debian.org/debian/wcurl
+https://github.com/curl/wcurl
 .SH COPYRIGHT
 \fBwcurl\fR is licensed under the curl license
 .SH SEE ALSO


### PR DESCRIPTION
After having moved off from living in the Debian org