### PR TITLE
Fix typo in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ should be using curl directly if your use case is not covered.
 * **--curl-options, curl-options=&lt;CURL\_OPTIONS&gt;**...  
   Specify extra options to be passed when invoking curl. May be specified more than once.
 
-* **-dry-run**  
+* **--dry-run**  
   Don't actually execute curl, just print what would be invoked.
 
 * **-V, --version**  


### PR DESCRIPTION
There was one minus missing in the option for dry run which bothered me,
fix this by adding the missing symbol.
