### PR TITLE
Improve/simplify LICENSE files (and create AUTHORS file)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,12 @@
+<!--
+Copyright (C) Samuel Henrique <samueloph@debian.org>, Sergio Durigan Junior <sergiodj@debian.org> and many contributors, see the AUTHORS file.
+
+SPDX-License-Identifier: curl
+-->
+Ben Zanin
+Daniel Stenberg <daniel@haxx.se>
+Guilherme Puida <guilherme@puida.xyz>
+Ryan Carsten Schmidt <git@ryandesign.com>
+Samuel Henrique <samueloph@debian.org>
+Sergio Durigan Junior <sergiodj@debian.org>
+Viktor Szakats

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,8 @@
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright (C) Samuel Henrique, <samueloph@debian.org>.
-Copyright (C) Sergio Durigan Junior, <sergiodj@debian.org>
-Copyright (C) Ryan Carsten Schmidt <git@ryandesign.com>
-Copyright (C) Ben Zanin
+Copyright (C) Samuel Henrique <samueloph@debian.org>, Sergio Durigan
+Junior <sergiodj@debian.org> and many contributors, see the AUTHORS
+file.
 
 All rights reserved.
 

--- a/LICENSES/curl.txt
+++ b/LICENSES/curl.txt
@@ -1,7 +1,8 @@
 COPYRIGHT AND PERMISSION NOTICE
 
-Copyright (C) Daniel Stenberg, <daniel@haxx.se>, and many
-contributors, see the THANKS file.
+Copyright (C) Samuel Henrique <samueloph@debian.org>, Sergio Durigan
+Junior <sergiodj@debian.org> and many contributors, see the AUTHORS
+file.
 
 All rights reserved.
 


### PR DESCRIPTION
The list of authors will only grow, so it's better to reference it from the LICENSE files.

Closes #20