### PR TITLE
Add --output/-o flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ SPDX-License-Identifier: curl
 
 # Synopsis
 
-    wcurl [--curl-options <CURL_OPTIONS>]... [--dry-run] [--] <URL>...
-    wcurl [--curl-options=<CURL_OPTIONS>]... [--dry-run] [--] <URL>...
+    wcurl [--curl-options <CURL_OPTIONS>]... [-o|-O|--output <PATH>] [--dry-run] [--] <URL>...
+    wcurl [--curl-options=<CURL_OPTIONS>]... [--output=<PATH>] [--dry-run] [--] <URL>...
     wcurl -V|--version
     wcurl -h|--help
 
@@ -48,6 +48,12 @@ should be using curl directly if your use case is not covered.
 * `--curl-options, curl-options=<CURL_OPTIONS>`...
 
   Specify extra options to be passed when invoking curl. May be specified more than once.
+
+* `-o, -O, --output=<PATH>`
+
+  Use explicit output path instead of curl's --remote-name logic. If multiple
+  URLs are provided, all files will have the same name with a number appended to
+  the end (curl >= 7.83.0).
 
 * `--dry-run`
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -111,6 +111,14 @@ testUrlStartingWithDash()
     assertEquals "${ret}" "Unknown option: '-example.com'."
 }
 
+testOutputFileName()
+{
+    url='example.com'
+    ret=$(${WCURL_CMD} -o "test filename" ${url} 2>&1)
+    assertContains "Verify whether 'wcurl' correctly sets a custom output filename" "${ret}" '--output'
+    assertContains "Verify whether 'wcurl' correctly sets a custom output filename" "${ret}" 'test filename'
+}
+
 ## Ideas for tests:
 ##
 ## - URL with whitespace

--- a/wcurl
+++ b/wcurl
@@ -49,8 +49,8 @@ usage()
     cat << _EOF_
 ${PROGRAM_NAME} -- a simple wrapper around curl to easily download files.
 
-Usage: ${PROGRAM_NAME} [--curl-options <CURL_OPTIONS>] [--dry-run] [--] <URL>...
-       ${PROGRAM_NAME} [--curl-options=<CURL_OPTIONS>] [--dry-run] [--] <URL>...
+Usage: ${PROGRAM_NAME} [--curl-options <CURL_OPTIONS>] [--output <PATH>] [--dry-run] [--] <URL>...
+       ${PROGRAM_NAME} [--curl-options=<CURL_OPTIONS>] [--output=PATH] [--dry-run] [--] <URL>...
        ${PROGRAM_NAME} -h|--help
        ${PROGRAM_NAME} -V|--version
 
@@ -59,6 +59,9 @@ Options:
   --curl-options <CURL_OPTIONS>: Specify extra options to be
                                  passed when invoking curl. May be
                                  specified more than once.
+
+  -o,--output: Use explicit output path instead of curl's --remote-name-all
+               logic.
 
   --dry-run: Don't actually execute curl, just print what would be
              invoked.
@@ -88,13 +91,16 @@ CURL_OPTIONS=""
 # The URLs to be downloaded.
 URLS=""
 
+# Defaults to --remote-name-all. Can be overriden to explicit file name using
+# -o/--output.
+OUTPUT="--remote-name-all"
+
 # The parameters that will be passed per-URL to curl.
 readonly PER_URL_PARAMETERS="\
     --fail \
     --globoff \
     --location \
     --proto-default https \
-    --remote-name-all \
     --remote-time \
     --retry 10 \
     --retry-max-time 10 "
@@ -163,7 +169,7 @@ exec_curl() {
     NEXT_PARAMETER=""
     for url in ${URLS}; do
         # shellcheck disable=SC2086
-        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} ${CURL_OPTIONS} "${url}"
+        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} ${CURL_OPTIONS} "${OUTPUT}" "${url}"
         NEXT_PARAMETER="--next"
     done
 
@@ -189,6 +195,16 @@ while [ -n "${1-}" ]; do
 
         --dry-run)
             DRY_RUN="true"
+            ;;
+
+        --output=*)
+            opt=$(printf "%s\n" "${1}" | sed 's/^--output=//')
+            OUTPUT="-o${opt}"
+            ;;
+
+        -o|--output)
+            shift
+            OUTPUT="-o${1}"
             ;;
 
         -h|--help)

--- a/wcurl
+++ b/wcurl
@@ -49,28 +49,30 @@ usage()
     cat << _EOF_
 ${PROGRAM_NAME} -- a simple wrapper around curl to easily download files.
 
-Usage: ${PROGRAM_NAME} [--curl-options <CURL_OPTIONS>] [--output <PATH>] [--dry-run] [--] <URL>...
-       ${PROGRAM_NAME} [--curl-options=<CURL_OPTIONS>] [--output=PATH] [--dry-run] [--] <URL>...
+Usage: ${PROGRAM_NAME} [--curl-options <CURL_OPTIONS>]... [-o|-O|--output <PATH>] [--dry-run] [--] <URL>...
+       ${PROGRAM_NAME} [--curl-options=<CURL_OPTIONS>]... [--output=<PATH>] [--dry-run] [--] <URL>...
        ${PROGRAM_NAME} -h|--help
        ${PROGRAM_NAME} -V|--version
 
 Options:
 
-  --curl-options <CURL_OPTIONS>: Specify extra options to be
-                                 passed when invoking curl. May be
+  --curl-options <CURL_OPTIONS>: Specify extra options to be passed when invoking curl. May be
                                  specified more than once.
 
-  -o,--output: Use explicit output path instead of curl's --remote-name-all
-               logic.
+  -o, -O, --output <PATH>: Use explicit output path instead of curl's --remote-name logic. If
+                           multiple URLs are provided, all files will have the same name with a
+                           number appended to the end (curl >= 7.83.0).
 
-  --dry-run: Don't actually execute curl, just print what would be
-             invoked.
+  --dry-run: Don't actually execute curl, just print what would be invoked.
 
-  -V,--version: Print version information.
+  -V, --version: Print version information.
 
-  -h,--help: Print this usage message.
+  -h, --help: Print this usage message.
 
-  <URL>: The URL to be downloaded.  May be specified more than once.
+  <URL>: The URL to be downloaded. May be specified more than once.
+
+  <CURL_OPTIONS>: Any option supported by curl can be set here. This is not used by wcurl; it's
+                 instead forwarded to the curl invocation.
 _EOF_
 }
 
@@ -92,8 +94,9 @@ CURL_OPTIONS=""
 URLS=""
 
 # Defaults to --remote-name-all. Can be overriden to explicit file name using
-# -o/--output.
-OUTPUT="--remote-name-all"
+# -o/-O/--output.
+OUTPUT_PARAMETER="--remote-name-all"
+OUTPUT_PATH=""
 
 # The parameters that will be passed per-URL to curl.
 readonly PER_URL_PARAMETERS="\
@@ -169,7 +172,7 @@ exec_curl() {
     NEXT_PARAMETER=""
     for url in ${URLS}; do
         # shellcheck disable=SC2086
-        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} ${CURL_OPTIONS} "${OUTPUT}" "${url}"
+        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} ${CURL_OPTIONS} ${OUTPUT_PARAMETER} "${OUTPUT_PATH}" "${url}"
         NEXT_PARAMETER="--next"
     done
 
@@ -199,12 +202,14 @@ while [ -n "${1-}" ]; do
 
         --output=*)
             opt=$(printf "%s\n" "${1}" | sed 's/^--output=//')
-            OUTPUT="-o${opt}"
+            OUTPUT_PARAMETER="--output"
+            OUTPUT_PATH="${opt}"
             ;;
 
-        -o|--output)
+        -o|-O|--output)
             shift
-            OUTPUT="-o${1}"
+            OUTPUT_PARAMETER="--output"
+            OUTPUT_PATH="${1}"
             ;;
 
         -h|--help)

--- a/wcurl.1
+++ b/wcurl.1
@@ -68,6 +68,11 @@ By default, \fBwcurl\fR will:
 \fB\-\-curl\-options, \-\-curl\-options=\fI<CURL_OPTIONS>\fR...\fR
 Specify extra options to be passed when invoking curl. May be specified more than once.
 .TP
+\fB\-o, \-O, \-\-output=\fI<PATH>\fR...\fR
+Use explicit output path instead of curl's --remote-name logic. If multiple
+URLs are provided, all files will have the same name with a number appended to
+the end (curl >= 7.83.0).
+.TP
 \fB\-\-dry\-run\fR
 Don't actually execute curl, just print what would be invoked.
 .TP


### PR DESCRIPTION
`--remote-name-all` is good default choice, but overriding the default inferred file name is still useful.

One could argue that one should use plain `curl` at this point, but `wcurl` still has lots of good defaults that are missing in plain `curl` binary and tedious to specify manually.

`--curl-options=-owhatever` is an option, but that's also very verbose.

Compare

    sudo curl -fLOp /usr/local/sbin/wcurl https://raw.githubusercontent.com/curl/wcurl/main/wcurl

    sudo wcurl --curl-options=-o/usr/local/sbin/wcurl https://raw.githubusercontent.com/curl/wcurl/main/wcurl

    sudo wcurl -o /usr/local/sbin/wcurl https://raw.githubusercontent.com/curl/wcurl/main/wcurl

And the first one with plain `curl` still misses a lot of good `wcurl` defaults.