### PR TITLE
Fix silent test failures enforcing min shunit2 version

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -32,6 +32,14 @@ export PATH="${ROOTDIR}:${PATH}"
 
 readonly WCURL_CMD="wcurl --dry-run "
 
+oneTimeSetUp() {
+    if ! assertContains "Check compatibility" "test" "test"; then
+        echo "Error: shunit2 version 2.1.8 or higher is required."
+        echo "Please install a compatible version of shunit2."
+        exit 1
+    fi
+}
+
 debug()
 {
     if [ -n "${DEBUG}" ]; then


### PR DESCRIPTION


This pull request addresses silent test failures due to an outdated version of `shunit2`. It introduces a compatibility check to ensure that `shunit2` version **2.1.8** or **higher** is installed before running the tests.

If the required version is not met, an informative error message is displayed, guiding users on how to resolve the issue.

A new script file `compatibility.sh` has been added to perform this check, and `tests.sh` now calls this script at the start to enforce the minimum version requirement.

## Validation

1. Environment running version `2.1.6`

```bash
podman run -v `pwd`:/home -w /home -it ubuntu:jammy bash
apt update && apt install -y curl shunit2
./tests/tests.sh

Error: shunit2 version 2.1.8 or higher is required.
Please install a compatible version of shunit2.
```

2. Environment running version `2.1.8`

```bash
./tests/tests.sh 
testUsage
testNoOptionError
testInvalidOptionError
testParallelIfMoreThanOneUrl
testEncodingWhitespace
testDoubleDash
testCurlOptions
testNextAmount
testUrlStartingWithDash
testOutputFileName
testOutputFileNameRepeatedOption
testUrlDefaultName
testUrlDefaultNameTrailingSlash
testUrlDecodingWhitespaces
testUrlDecodingWhitespacesTwoFiles
testUrlDecodingDisabled
testUrlDecodingWhitespacesQueryString
testUrlDecodingWhitespacesTrailingSlash
testUrlDecodingNonLatinLanguages

Ran 19 tests.

OK
```

Closes: #39

