### PR TITLE
Allow -o and -O to be used without whitespaces (e.g.: -oNAME)

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -132,6 +132,14 @@ testOutputFileName()
     assertContains "Verify whether 'wcurl' correctly sets a custom output filename" "${ret}" 'test filename'
 }
 
+testOutputFileNameWithoutSpaces()
+{
+    url='example.com'
+    ret=$(${WCURL_CMD} -o"test filename" ${url} 2>&1)
+    assertContains "Verify whether 'wcurl' correctly sets --output" "${ret}" '--output'
+    assertContains "Verify whether 'wcurl' correctly sets --output with the correct filename" "${ret}" 'test filename'
+}
+
 testOutputFileNameRepeatedOption()
 {
     url='example.com'

--- a/wcurl
+++ b/wcurl
@@ -275,6 +275,12 @@ while [ -n "${1-}" ]; do
             OUTPUT_PATH="${1}"
             ;;
 
+        -o*|-O*)
+            opt=$(printf "%s\n" "${1}" | sed 's/^-[oO]//')
+            HAS_USER_SET_OUTPUT="true"
+            OUTPUT_PATH="${opt}"
+            ;;
+
         --no-decode-filename)
             DECODE_FILENAME="false"
             ;;


### PR DESCRIPTION
 Thanks to MithicSpirit for the suggestion.

 Closes #42