### PR TITLE
Add example for downloading a list of URLs from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ then performs the parsing. May be specified more than once.
   wcurl --curl-options="--continue-at -" example.com/filename.txt
   ```
 
+* Download a list of URLs from a file:
+
+  ```sh
+  while read -r url; do wcurl "$url"; done < filename.txt
+   ```
+
 # Running the testsuite
 
 If you would like to run the tests, you first need to install the

--- a/wcurl.md
+++ b/wcurl.md
@@ -129,6 +129,10 @@ be the last one in the list):
 
 **wcurl --curl-options="--continue-at -" example.com/filename.txt**
 
+Download a list of URLs from a file:
+
+**while read -r url; do wcurl "$url"; done < filename.txt**
+
 # AUTHORS
 
     Samuel Henrique \<samueloph@debian.org\>


### PR DESCRIPTION
I haven't thoroughly tested this and checked for corner cases yet, but does it make sense to document this usecase in the manpage?

Pending:
- [ ] Check corner cases, e.g.: whitespaces, carriage return, breaklines, tabs...
- [ ] Check non GNU/Linux portability.