### PR TITLE
Fix example for "continue-at"

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ then performs the parsing. May be specified more than once.
   wcurl --curl-options="--progress-bar --http2" example.com/filename.txt
   ```
 
-* Resume from an interrupted download (if more options are used, this needs to be the last one in the list):
+* Resume from an interrupted download. The options necessary to resume the download (`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`. Note that the only way to resume interrupted downloads is to allow wcurl to overwrite the destination file:
 
   ```sh
-  wcurl --curl-options="--continue-at -" example.com/filename.txt
+  wcurl --curl-options="--clobber --continue-at -" example.com/filename.txt
   ```
 
 # Running the testsuite

--- a/wcurl.md
+++ b/wcurl.md
@@ -124,10 +124,9 @@ Download a file passing the **--progress-bar** and **--http2** flags to curl:
 
 **wcurl --curl-options="--progress-bar --http2" example.com/filename.txt**
 
-Resume from an interrupted download (if more options are used, this needs to
-be the last one in the list):
+* Resume from an interrupted download. The options necessary to resume the download (`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`. Note that the only way to resume interrupted downloads is to allow wcurl to overwrite the destination file:
 
-**wcurl --curl-options="--continue-at -" example.com/filename.txt**
+**wcurl --curl-options="--clobber --continue-at -" example.com/filename.txt**
 
 # AUTHORS
 


### PR DESCRIPTION
 It stopped working after we introduced the "--no-clobber" option, to
 make the example work again we just need to explicitly override it with
 "--clobber".

 Thanks to Thomas Braun for reporting it.

 Closes: https://github.com/curl/wcurl/issues/61