### PR TITLE
Set CURL_OPTIONS right before the url

### DIFF
--- a/wcurl
+++ b/wcurl
@@ -231,7 +231,7 @@ exec_curl()
             [ -z "${OUTPUT_PATH}" ] && OUTPUT_PATH=index.html
         fi
         # shellcheck disable=SC2086
-        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} ${CURL_OPTIONS} --output "${OUTPUT_PATH}" "${url}"
+        set -- "$@" ${NEXT_PARAMETER} ${PER_URL_PARAMETERS} ${CURL_HAS_NO_CLOBBER} --output "${OUTPUT_PATH}" ${CURL_OPTIONS} "${url}"
         NEXT_PARAMETER="--next"
     done
 


### PR DESCRIPTION
 I'm reordering the parameters used in the curl invocation to have
 "CURL-OPTIONS" be set for last, allowing "--output" to also be
 overwritten and making the curl invocation more clear, as having
 "--continue-at -" not right before the URL looks weird.

 As far as my tests went, this has no functionality side effect other
 than allowing "output" to be set by the user.