### PR TITLE
replace `>/dev/stderr` with `>&2` for portability

### DIFF
--- a/wcurl
+++ b/wcurl
@@ -85,7 +85,7 @@ _EOF_
 # Display an error message and bail out.
 error()
 {
-    printf "%s\n" "$*" > /dev/stderr
+    printf "%s\n" "$*" >&2
     exit 1
 }
 


### PR DESCRIPTION
Fixes this error in environments missing `/dev/stderr`:
```
wcurl: line 88: can't create /dev/stderr: nonexistent directory
```

Seen on Windows with `busybox.exe`:
https://frippery.org/busybox/
