### PR TITLE
manual: fold a long line

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,10 @@ then performs the parsing. May be specified more than once.
   wcurl --curl-options="--progress-bar --http2" example.com/filename.txt
   ```
 
-* Resume from an interrupted download. The options necessary to resume the download (`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`. Note that the only way to resume interrupted downloads is to allow wcurl to overwrite the destination file:
+* Resume from an interrupted download. The options necessary to resume the download
+  (`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`.
+  Note that the only way to resume interrupted downloads is to allow wcurl to overwrite
+  the destination file:
 
   ```sh
   wcurl --curl-options="--clobber --continue-at -" example.com/filename.txt

--- a/wcurl.1
+++ b/wcurl.1
@@ -95,7 +95,10 @@ Download a file passing the \fB\--progress\-bar\fP and \fB\--http2\fP flags to c
 
 \fBwcurl \--curl\-options="\--progress\-bar \--http2" example.com/filename.txt\fP
 
-* Resume from an interrupted download. The options necessary to resume the download (\fI\--clobber \--continue\-at \-\fP) must be the \fBlast\fP options specified in \fI\--curl\-options\fP. Note that the only way to resume interrupted downloads is to allow wcurl to overwrite the destination file:
+Resume from an interrupted download. The options necessary to resume the download
+(\fI\--clobber \--continue\-at \-\fP) must be the \fBlast\fP options specified in \fI\--curl\-options\fP.
+Note that the only way to resume interrupted downloads is to allow wcurl to overwrite
+the destination file:
 
 \fBwcurl \--curl\-options="\--clobber \--continue\-at \-" example.com/filename.txt\fP
 

--- a/wcurl.md
+++ b/wcurl.md
@@ -127,7 +127,10 @@ Download a file passing the **--progress-bar** and **--http2** flags to curl:
 
 **wcurl --curl-options="--progress-bar --http2" example.com/filename.txt**
 
-* Resume from an interrupted download. The options necessary to resume the download (`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`. Note that the only way to resume interrupted downloads is to allow wcurl to overwrite the destination file:
+Resume from an interrupted download. The options necessary to resume the download
+(`--clobber --continue-at -`) must be the **last** options specified in `--curl-options`.
+Note that the only way to resume interrupted downloads is to allow wcurl to overwrite
+the destination file:
 
 **wcurl --curl-options="--clobber --continue-at -" example.com/filename.txt**
 


### PR DESCRIPTION
- fold copies of a long line in README.md, wcurl.1 and wcurl.md.

- omit stray `*` lead from wcurl.1 and wcurl.md in the line above,
  to sync with other examples.

Ref: https://github.com/curl/curl/pull/21087
