### PR TITLE
wcurl: disable shell glob expansion

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -268,7 +268,6 @@ testUrlDecodingNonLatinLanguages()
 
 testGlobExpansion()
 {
-    local tmpdir
     tmpdir="$(mktemp -d)"
     mkdir "${tmpdir}/example.com"
     touch "${tmpdir}/example.com/file"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -266,5 +266,12 @@ testUrlDecodingNonLatinLanguages()
 ## - Options are the same for all URLs (except --next)
 ## - URLs beginning with '-' (with and without using '--')
 
+testGlobExpansion()
+{
+    url='example.com/*'
+    ret=$(${WCURL_CMD} "${url}" 2>&1)
+    assertContains "Verify whether 'wcurl' protects URLs from glob expansion" "${ret}" 'example.com/*'
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -268,8 +268,16 @@ testUrlDecodingNonLatinLanguages()
 
 testGlobExpansion()
 {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    mkdir "${tmpdir}/example.com"
+    touch "${tmpdir}/example.com/file"
+
     url='example.com/*'
-    ret=$(${WCURL_CMD} "${url}" 2>&1)
+    ret=$(cd "${tmpdir}" && ${WCURL_CMD} "${url}" 2>&1)
+
+    rm -rf "${tmpdir}"
+
     assertContains "Verify whether 'wcurl' protects URLs from glob expansion" "${ret}" 'example.com/*'
 }
 

--- a/wcurl
+++ b/wcurl
@@ -26,7 +26,7 @@
 #
 # SPDX-License-Identifier: curl
 
-# Stop on errors, usage of unset variables and glob expansion.
+# Stop on errors, usage of unset variables and disable glob expansion.
 set -euf
 
 VERSION="2026.01.05"

--- a/wcurl
+++ b/wcurl
@@ -26,7 +26,7 @@
 #
 # SPDX-License-Identifier: curl
 
-# Stop on errors and on usage of unset variables.
+# Stop on errors, usage of unset variables and glob expansion.
 set -euf
 
 VERSION="2026.01.05"

--- a/wcurl
+++ b/wcurl
@@ -27,7 +27,7 @@
 # SPDX-License-Identifier: curl
 
 # Stop on errors and on usage of unset variables.
-set -eu
+set -euf
 
 VERSION="2026.01.05"
 


### PR DESCRIPTION
This PR disables shell glob expansion globally by changing `set -eu` to `set -euf`.

Why? because when i was using the wcurl, i noticed it has no reason to ever expand shell file globs like `*` or `?`. By failing to disable globing, unquoted variables (such as `$URLS` inside `exec_curl()` and `${CURL_OPTIONS}`) trigger pathname expansion against the current working directory. 

For example,

Consider this,
 `wcurl 'example.com/file[1-3]'` .....  currently fails by resolving local files and passing multiple incorrect strings to curl instead of the literal URL. The `--globoff` parameter passed to curl does not prevent the POSIX shell from expanding it first. Using `set -f` cleanly resolves this without side effects.

Added testing `testGlobExpansion` to `tests.sh` to ensure URLs with `*` are successfully passed to curl literally.

I would suggest adding contribution.MD, I followed the one with trurl, where i had committed before  