### PR TITLE
wcurl: strip URL fragment identifier from output filename

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -266,5 +266,12 @@ testUrlDecodingNonLatinLanguages()
 ## - Options are the same for all URLs (except --next)
 ## - URLs beginning with '-' (with and without using '--')
 
+testFragmentStripping()
+{
+    url='example.com/document.pdf#page=5'
+    ret=$(${WCURL_CMD} "${url}" 2>&1 | tr '\n' ' ')
+    assertContains "Verify whether 'wcurl' correctly strips #fragments from filenames" "${ret}" '--output document.pdf '
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/wcurl
+++ b/wcurl
@@ -190,7 +190,7 @@ percent_decode()
 get_url_filename()
 {
     # Remove protocol and query string if present.
-    hostname_and_path="$(printf %s "${1}" | sed -e 's,^[^/]*//,,' -e 's,?.*$,,')"
+    hostname_and_path="$(printf %s "${1}" | sed -e 's,^[^/]*//,,' -e 's,[?#].*$,,')"
     # If what remains contains a slash, there is a path; return it percent-decoded.
     case "${hostname_and_path}" in
         # sed to remove everything preceding the last '/', e.g.: "example/something" becomes "something"


### PR DESCRIPTION
This PR is for updatng `get_url_filename()` to strip URL fragments (`#`) identically to how it strips query strings (`?`). 

Reason to do this is when someone try extracting a filename from a URL, wcurl currently strips everything after `?`. however, if the URL contains a fragment.... (e.g. `example.com/document.pdf#page=5`), the filename is generated locally as ....`document.pdf#page=5`. According to RFC (Idk exact number did just AI to confirm) , the fragment identifier is client-side metadata and thus is not part of the physical file name or path.

This is fixed by changing the `sed` substitution to match `[?#]` instead of just `?`, a small regex change. 

Testing
Added `testFragmentStripping` to `tests.sh` to verify `#fragments` are correctly stripped from the output filename.