### PR TITLE
wcurl: fix missing argument crash for options

### DIFF
--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -273,5 +273,16 @@ testFragmentStripping()
     assertContains "Verify whether 'wcurl' correctly strips #fragments from filenames" "${ret}" '--output document.pdf '
 }
 
+testMissingArgumentError()
+{
+    ret=$(${WCURL_CMD} --curl-options 2>&1)
+    assertFalse "Verify whether 'wcurl' with missing argument exits with an error" "$?"
+    assertEquals "Verify whether 'wcurl' displays missing argument error for --curl-options" "${ret}" "Option '--curl-options' requires an argument."
+
+    ret=$(${WCURL_CMD} -o 2>&1)
+    assertFalse "Verify whether 'wcurl' with missing argument exits with an error" "$?"
+    assertEquals "Verify whether 'wcurl' displays missing argument error for -o" "${ret}" "Option '-o' requires an argument."
+}
+
 # shellcheck disable=SC1091
 . shunit2

--- a/wcurl
+++ b/wcurl
@@ -283,6 +283,9 @@ while [ -n "${1-}" ]; do
             ;;
 
         --curl-options)
+            if [ -z "${2-}" ]; then
+                error "Option '${1}' requires an argument."
+            fi
             shift
             CURL_OPTIONS="${CURL_OPTIONS} ${1}"
             ;;
@@ -298,6 +301,9 @@ while [ -n "${1-}" ]; do
             ;;
 
         -o | -O | --output)
+            if [ -z "${2-}" ]; then
+                error "Option '${1}' requires an argument."
+            fi
             shift
             HAS_USER_SET_OUTPUT="true"
             OUTPUT_PATH="${1}"


### PR DESCRIPTION
This PR adds input validation checks before `shift` is called for the `--curl-options` and `-o`/`-O`/`--output` parameters.

Currently, if a user passes `--curl-options` or `-o` as the final argument without providing an actual value, the script blindly calls `shift` and then attempts to read `${1}`. Because the script correctly uses `set -eu`, reading an unbound variable immediately crashes the program with an ugly shell interpreter error (`unbound variable` or `parameter not set`)....

 instead of a helpful user-facing error.

This is a small patch .... which catches the missing parameter and gracefully reports it using the `error()` function.

small test is also added here `testMissingArgumentError` to `tests.sh` to explicitly verify behavior when an argument is omitted.