### PR TITLE
wcurl: prevent silent overwrite with --output on older curl

### DIFF
--- a/wcurl
+++ b/wcurl
@@ -240,6 +240,8 @@ exec_curl()
     # If there are less than two URLs, do not set the parallel flag.
     if [ "$#" -lt 2 ]; then
         CURL_PARALLEL=""
+    elif [ "${HAS_USER_SET_OUTPUT}" = "true" ] && [ -z "${CURL_NO_CLOBBER}" ]; then
+        error "Using --output with multiple URLs requires curl >= 7.83.0 (--no-clobber)."
     fi
 
     # Start assembling the command.

--- a/wcurl
+++ b/wcurl
@@ -241,7 +241,7 @@ exec_curl()
     if [ "$#" -lt 2 ]; then
         CURL_PARALLEL=""
     elif [ "${HAS_USER_SET_OUTPUT}" = "true" ] && [ -z "${CURL_NO_CLOBBER}" ]; then
-        error "Using --output with multiple URLs requires curl >= 7.83.0 (--no-clobber)."
+        error "Using '--output' with multiple URLs requires curl >= 7.83.0 ('--no-clobber')."
     fi
 
     # Start assembling the command.


### PR DESCRIPTION

Well this PR is a small one and just adds a defensive check to `exec_curl()` to return an error when the user explicitly passes `--output` alongside multiple URLs, but has a curl version older than `7.83.0`, but this is something that caused me too much frustration. 


In current scenatio what happens is when `--output` is explicitly provided, wcurl uses the identical `OUTPUT_PATH` for every single URL in the loop. 

On modern curl versions, `--no-clobber` correctly prevents overwrites by appending numeric suffixes (`.1`, `.2`, etc.). 

However, wcurl project supports curl `7.46.0` and higher. 

On versions prior to`7.83.0` ( based on change logs) , the `--no-clobber` flag is missing, causing multiple file downloads to silently overwrite the same local file sequentially.

This throws a user-facing error to prevent silent data loss, and not leave them clueless 
