### PR TITLE
omit or replace the word 'just'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ SPDX-License-Identifier: curl
  * Stop auto-resuming downloads and do not overwrite files instead by default.
    Safer alternative as otherwise curl can corrupt a file if the name clashes and the size of the existing one is smaller.
    One can easily change that behavior with `--curl-options="--continue-at -"`.
- * New `--dry-run` option: just print what would be invoked.
+ * New `--dry-run` option: print what would be invoked.
  * Choose HTTPS as a default protocol, in case there is none in the URL.
  * Disable curl's URL globbing parser so `{}` and `[]` characters in URLs are not treated specially.
  * Implement support for `--`.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Simply call **wcurl** with a list of URLs you want to download and **wcurl** pic
 sane defaults.
 
 If you need anything more complex, you can provide any of curl's supported
-parameters via the `--curl-options` option. Just beware that you likely
-should be using curl directly if your use case is not covered.
+parameters via the `--curl-options` option. Beware that you likely should
+be using curl directly if your use case is not covered.
 
 * By default, **wcurl** does:
   * Percent-encode whitespace in URLs;
@@ -93,7 +93,7 @@ should be using curl directly if your use case is not covered.
 
 * `--dry-run`
 
-  Do not actually execute curl, just print what would be invoked.
+  Do not actually execute curl, print what would be invoked.
 
 * `-V, --version`
 

--- a/wcurl
+++ b/wcurl
@@ -67,7 +67,7 @@ Options:
   --no-decode-filename: Do not percent-decode the output filename, even if the percent-encoding in
                         the URL was done by wcurl, e.g.: The URL contained whitespace.
 
-  --dry-run: Do not actually execute curl, just print what would be invoked.
+  --dry-run: Do not actually execute curl, print what would be invoked.
 
   -V, --version: Print version information.
 
@@ -197,7 +197,7 @@ get_url_filename()
         # sed to also replace ':' with the percent_encoded %3A
         */*) percent_decode "$(printf %s "${hostname_and_path}" | sed -e 's,^.*/,,' -e 's,:,%3A,g')" ;;
     esac
-    # No slash means there was just a hostname and no path; return empty string.
+    # No slash means there was only a hostname and no path; return empty string.
 }
 
 # Execute curl with the list of URLs provided by the user.

--- a/wcurl.1
+++ b/wcurl.1
@@ -20,8 +20,8 @@ Simply call \fBwcurl\fP with a list of URLs you want to download and \fBwcurl\fP
 picks sane defaults.
 
 If you need anything more complex, you can provide any of curl\(aqs supported
-parameters via the \fB\--curl\-options\fP option. Just beware that you likely
-should be using curl directly if your use case is not covered.
+parameters via the \fB\--curl\-options\fP option. Beware that you likely should
+be using curl directly if your use case is not covered.
 
 By default, \fBwcurl\fP does:
 .IP "* Percent-encode whitespace in URLs;"
@@ -70,7 +70,7 @@ last value is considered.
 Do not percent\-decode the output filename, even if the percent\-encoding in the
 URL was done by \fBwcurl\fP, e.g.: The URL contained whitespace.
 .IP --dry-run
-Do not actually execute curl, just print what would be invoked.
+Do not actually execute curl, print what would be invoked.
 .IP "-V, \--version"
 Print version information.
 .IP "-h, \--help"

--- a/wcurl.md
+++ b/wcurl.md
@@ -35,8 +35,8 @@ Simply call **wcurl** with a list of URLs you want to download and **wcurl**
 picks sane defaults.
 
 If you need anything more complex, you can provide any of curl's supported
-parameters via the **--curl-options** option. Just beware that you likely
-should be using curl directly if your use case is not covered.
+parameters via the **--curl-options** option. Beware that you likely should
+be using curl directly if your use case is not covered.
 
 By default, **wcurl** does:
 
@@ -92,7 +92,7 @@ URL was done by **wcurl**, e.g.: The URL contained whitespace.
 
 ## --dry-run
 
-Do not actually execute curl, just print what would be invoked.
+Do not actually execute curl, print what would be invoked.
 
 ## -V, \--version
 


### PR DESCRIPTION
To fit curl's 'badwords' checker.
