### PR TITLE
avoid the word 'simply'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ repositories, `wcurl` might be shipped as part of the `curl` package.
 
 If they do not ship it, consider making a request for it.
 
-You can always install wcurl by simply downloading the script:
+You can always install wcurl by downloading the script:
 
 ```sh
 curl -fLO https://github.com/curl/wcurl/releases/latest/download/wcurl
@@ -53,7 +53,7 @@ wcurl -h|--help
 **wcurl** is a simple curl wrapper which lets you use curl to download files
 without having to remember any parameters.
 
-Simply call **wcurl** with a list of URLs you want to download and **wcurl** picks
+Call **wcurl** with a list of URLs you want to download and **wcurl** picks
 sane defaults.
 
 If you need anything more complex, you can provide any of curl's supported
@@ -155,8 +155,7 @@ If you would like to run the tests, you first need to install the
 `shunit2` package.  On Debian-like and Fedora-like systems, the
 package is called `shunit2`.
 
-After that, you can run the testsuite by simply invoking the test
-script:
+After that, you can run the testsuite by invoking the test script:
 
 ```sh
 ./tests/tests.sh

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: Daniel Stenberg, <daniel@haxx.se>, et al.
 
 # This file describes the licensing and copyright situation for files that
-# cannot be annotated directly, for example because of being simply
-# uncommentable. Unless this is the case, a file should be annotated directly.
+# cannot be annotated directly, for example because of being uncommentable.
+# Unless this is the case, a file should be annotated directly.
 #
 # This follows the REUSE specification: https://reuse.software/spec-3.2/#reusetoml
 

--- a/wcurl.1
+++ b/wcurl.1
@@ -16,7 +16,7 @@
 \fBwcurl\fP is a simple curl wrapper which lets you use curl to download files
 without having to remember any parameters.
 
-Simply call \fBwcurl\fP with a list of URLs you want to download and \fBwcurl\fP
+Call \fBwcurl\fP with a list of URLs you want to download and \fBwcurl\fP
 picks sane defaults.
 
 If you need anything more complex, you can provide any of curl\(aqs supported

--- a/wcurl.md
+++ b/wcurl.md
@@ -31,7 +31,7 @@ Added-in: n/a
 **wcurl** is a simple curl wrapper which lets you use curl to download files
 without having to remember any parameters.
 
-Simply call **wcurl** with a list of URLs you want to download and **wcurl**
+Call **wcurl** with a list of URLs you want to download and **wcurl**
 picks sane defaults.
 
 If you need anything more complex, you can provide any of curl's supported


### PR DESCRIPTION
To fit curl's 'badwords' checker.
